### PR TITLE
記事更新時に更新元ファイルのentryHeaderのURLが未設定の場合も更新ができるように修正

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -153,7 +153,7 @@ func (b *broker) PutEntry(e *entry) error {
 	if e.CustomPath != "" {
 		newEntry.CustomPath = e.CustomPath
 	}
-	return b.Store(newEntry, b.LocalPath(newEntry), b.LocalPath(e))
+	return b.Store(newEntry, b.LocalPath(newEntry), b.originalPath(e))
 }
 
 func (b *broker) PostEntry(e *entry, isPage bool) error {
@@ -172,6 +172,13 @@ func (b *broker) PostEntry(e *entry, isPage bool) error {
 	}
 
 	return b.Store(newEntry, b.LocalPath(newEntry), "")
+}
+
+func (b *broker) originalPath(e *entry) string {
+	if e.URL == nil {
+		return ""
+	}
+	return b.LocalPath(e)
 }
 
 func atomEndpointURLRoot(bc *blogConfig) string {

--- a/broker_test.go
+++ b/broker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 
@@ -47,9 +48,10 @@ func TestOriginalPath(t *testing.T) {
 	d := time.Date(2023, 10, 10, 0, 0, 0, 0, jst)
 
 	testCases := []struct {
-		name   string
-		entry  entry
-		expect string
+		name          string
+		entry         entry
+		expect        string
+		expectWindows string
 	}{
 		{
 			name: "entry has URL",
@@ -64,7 +66,8 @@ func TestOriginalPath(t *testing.T) {
 				LastModified: &d,
 				Content:      "テスト",
 			},
-			expect: "example1.hatenablog.com/2.md",
+			expect:        "example1.hatenablog.com/2.md",
+			expectWindows: "example1.hatenablog.com\\2.md",
 		},
 		{
 			name: "Not URL",
@@ -77,7 +80,8 @@ func TestOriginalPath(t *testing.T) {
 				LastModified: &d,
 				Content:      "テスト",
 			},
-			expect: "",
+			expect:        "",
+			expectWindows: "",
 		},
 	}
 
@@ -90,6 +94,9 @@ func TestOriginalPath(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := broker.originalPath(&tc.entry)
+			if runtime.GOOS == "windows" {
+				tc.expect = tc.expectWindows
+			}
 			assert.Equal(t, tc.expect, got)
 		})
 	}


### PR DESCRIPTION
## 背景

- https://github.com/hatena/hatenablog-workflows にて下書き記事の場合は, 特定の作業用ディレクトリに下書きファイルを配置し、メタデータから`URL`を意図的に削除した状態で運用し, 公開のタイミングでURLを設定するようにして運用しております
- しかし, https://github.com/x-motemen/blogsync/pull/83 の変更以降, entryHeaderの`URL`がない状態の記事を更新(push)した際にエラーが発生するようになりました
  - これはbroker.goの`LocalPath`内でentryに対して`URL`が設定されていることを想定した記述になっていたためのようでした
  - https://github.com/x-motemen/blogsync/blob/v0.15.0/broker.go#L90

## 解決策の提案

- `PutEntry`の処理内では, 更新元ファイルに`URL`が未設定の場合はorigPathに空白を返すように変更しました
  - この変更が適切かどうかやや心配なところもありますので, 一度ご確認いただけますと幸いです
